### PR TITLE
Support k8s v1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.1.1-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.2.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-vsphere?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -26,8 +26,8 @@ The following packages are included in the Fury Kubernetes vSphere module:
 
 | Package                                        | Version  | Description                                                                   |
 | ---------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
-| [vsphere-cm](katalog/vsphere-cm)               | `1.27.0` | Kubernetes Cloud Provider for vSphere                                         |
-| [vsphere-csi](katalog/vsphere-csi)             | `3.1.2`  | vSphere storage Container Storage Interface (CSI) plugin                      |
+| [vsphere-cm](katalog/vsphere-cm)               | `1.28.1` | Kubernetes Cloud Provider for vSphere                                         |
+| [vsphere-csi](katalog/vsphere-csi)             | `3.2.0`  | vSphere storage Container Storage Interface (CSI) plugin                      |
 
 Click on each package to see its full documentation.
 
@@ -50,7 +50,7 @@ List the bases in a `Furyfile.yml` file
 ```yaml
 bases:
   - name: vsphere
-    version: v1.1.1
+    version: v1.2.0
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,10 +1,11 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version |       1.26.X       |       1.27.X       |
-| ----------------------------------- | :----------------: | :----------------: |
-| v1.0.0                              | :white_check_mark: |                    |
-| v1.1.0                              | :white_check_mark: | :white_check_mark: |
-| v1.1.1                              | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version |       1.26.X       |       1.27.X       |       1.28.X       |
+| ----------------------------------- | :----------------: | :----------------: | :----------------: |
+| v1.0.0                              | :white_check_mark: |                    |                    |
+| v1.1.0                              | :white_check_mark: | :white_check_mark: |                    |
+| v1.1.1                              | :white_check_mark: | :white_check_mark: |                    |
+| v1.2.0                              |                    | :white_check_mark: | :white_check_mark: |
 
 |        Icon        | Legend       |
 | :----------------: | ------------ |

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -3,8 +3,8 @@
 | Module Version / Kubernetes Version |       1.26.X       |       1.27.X       |
 | ----------------------------------- | :----------------: | :----------------: |
 | v1.0.0                              | :white_check_mark: |                    |
-| v1.1.0                              |                    | :white_check_mark: |
-| v1.1.1                              |                    | :white_check_mark: |
+| v1.1.0                              | :white_check_mark: | :white_check_mark: |
+| v1.1.1                              | :white_check_mark: | :white_check_mark: |
 
 |        Icon        | Legend       |
 | :----------------: | ------------ |

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,0 +1,15 @@
+# vSphere add-on module release 1.2.0
+
+Welcome to the latest release of `vsphere` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
+
+This release adds support for kubernetes v1.28.
+
+## Package Versions 🚢
+
+| Package                          | Supported Version        | Previous Version |
+| -------------------------------- | ------------------------ | ---------------- |
+| [vmware-cm](katalog/vmware-cm)   | [1.28.1][cm-changelog]   | `1.27.0`         |
+| [vmware-csi](katalog/vmware-csi) | [3.2.0][csi-changelog]   | `3.1.2`          |
+
+[cm-changelog]: https://github.com/kubernetes/cloud-provider-vsphere/releases/tag/v1.28.1
+[csi-changelog]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html

--- a/katalog/vsphere-cm/vsphere-cloud-controller-manager.yaml
+++ b/katalog/vsphere-cm/vsphere-cloud-controller-manager.yaml
@@ -234,7 +234,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
-          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.27.0
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.28.1
           args:
             - --cloud-provider=vsphere
             - --v=2

--- a/katalog/vsphere-csi/vsphere-csi-driver.yaml
+++ b/katalog/vsphere-csi/vsphere-csi-driver.yaml
@@ -62,20 +62,20 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
     verbs: ["create", "get", "list", "update", "delete"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotclasses"]
-    verbs: ["watch", "get", "list"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents/status"]
-    verbs: ["update", "patch"]
-  - apiGroups: ["cns.vmware.com"]
-    resources: ["csinodetopologies"]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshots" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotclasses" ]
+    verbs: [ "watch", "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents/status" ]
+    verbs: [ "update", "patch" ]
+  - apiGroups: [ "cns.vmware.com" ]
+    resources: [ "csinodetopologies" ]
     verbs: ["get", "update", "watch", "list"]
 ---
 kind: ClusterRoleBinding
@@ -148,21 +148,8 @@ roleRef:
 ---
 apiVersion: v1
 data:
-  "csi-migration": "true"
-  "csi-auth-check": "true"
-  "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
-  "async-query-volume": "true"
-  "block-volume-snapshot": "true"
-  "csi-windows-support": "true"
-  "list-volumes": "true"
   "pv-to-backingdiskobjectid-mapping": "false"
-  "cnsmgr-suspend-create-volume": "true"
-  "topology-preferential-datastores": "true"
-  "max-pvscsi-targets-per-vm": "true"
-  "multi-vcenter-csi-topology": "true"
-  "csi-internal-generated-cluster-id": "true"
-  "listview-tasks": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
@@ -243,7 +230,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -261,7 +248,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -280,7 +267,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.2.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -302,6 +289,8 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: GODEBUG
+              value: x509sha1=1,tlsmaxrsasize=16384
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -332,7 +321,7 @@ spec:
             periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -340,7 +329,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.2.0
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -365,7 +354,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -379,7 +368,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -401,7 +390,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -452,7 +441,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -475,7 +464,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.2.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -497,8 +486,6 @@ spec:
               value: "true"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
-            - name: GODEBUG
-              value: x509sha1=1
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -537,7 +524,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
Add support for Kubernetes v1.28 according to the upstream's compatibility matrices.

The Controller Manager has uses the same major and minor version as kubernetes but the CSI v3.2.0 supports kubernetes versions from v1.27 to v1.29.

Let me know how to proceed for the release