### PR TITLE
[FEAT]upgrade vsphere module - task 507

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The following packages are included in the Fury Kubernetes vSphere module:
 
 | Package                                        | Version  | Description                                                                   |
 | ---------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
-| [vsphere-cm](katalog/vsphere-cm)               | `1.29.0` | Kubernetes Cloud Provider for vSphere                                         |
-| [vsphere-csi](katalog/vsphere-csi)             | `3.2.0`  | vSphere storage Container Storage Interface (CSI) plugin                      |
+| [vsphere-cm](katalog/vsphere-cm)               | `1.30.0` | Kubernetes Cloud Provider for vSphere                                         |
+| [vsphere-csi](katalog/vsphere-csi)             | `3.3.1`  | vSphere storage Container Storage Interface (CSI) plugin                      |
 
 Click on each package to see its full documentation.
 
@@ -41,7 +41,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 | Tool                    | Version   | Description                                                                                                                                                |
 | ----------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo] | `>=0.25.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo]. |
+| [furyctl][furyctl-repo] | `>=0.29.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo]. |
 
 ### Download the packages
 
@@ -50,7 +50,7 @@ List the bases in a `Furyfile.yml` file
 ```yaml
 bases:
   - name: vsphere
-    version: v1.3.0
+    version: v1.4.0
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,12 +1,13 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version |       1.26.X       |       1.27.X       |       1.28.X       |       1.29.X       |
-| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: |
-| v1.0.0                              | :white_check_mark: |                    |                    |                    |
-| v1.1.0                              | :white_check_mark: | :white_check_mark: |                    |                    |
-| v1.1.1                              | :white_check_mark: | :white_check_mark: |                    |                    |
-| v1.2.0                              |                    | :white_check_mark: | :white_check_mark: |                    |
-| v1.3.0                              |                    |                    | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version |       1.26.X       |       1.27.X       |       1.28.X       |       1.29.X       |       1.30.X       |
+| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| v1.0.0                              | :white_check_mark: |                    |                    |                    |                    |
+| v1.1.0                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.1.1                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.2.0                              |                    | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.3.0                              |                    |                    | :white_check_mark: | :white_check_mark: |                    |
+| v1.4.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: |
 
 |        Icon        | Legend       |
 | :----------------: | ------------ |

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,4 +1,4 @@
-# vSphere add-on module release 1.3.0
+# vSphere add-on module release 1.4.0
 
 Welcome to the latest release of `vsphere` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
 

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -2,7 +2,7 @@
 
 Welcome to the latest release of `vsphere` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
 
-This release adds support for kubernetes v1.29.
+This release adds support for kubernetes v1.30
 
 ## Package Versions 🚢
 

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,0 +1,15 @@
+# vSphere add-on module release 1.3.0
+
+Welcome to the latest release of `vsphere` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by SIGHUP team.
+
+This release adds support for kubernetes v1.29.
+
+## Package Versions 🚢
+
+| Package                          | Supported Version        | Previous Version |
+| -------------------------------- | ------------------------ | ---------------- |
+| [vmware-cm](katalog/vmware-cm)   | [1.30.0][cm-changelog]   | `1.29.0`         |
+| [vmware-csi](katalog/vmware-csi) | [3.3.1][csi-changelog]   | `3.2.1`          |
+
+[cm-changelog]: https://github.com/kubernetes/cloud-provider-vsphere/releases/tag/v1.30.1
+[csi-changelog]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html

--- a/katalog/vsphere-cm/README.md
+++ b/katalog/vsphere-cm/README.md
@@ -4,7 +4,7 @@ This katalog deploys the [vSphere Cloud Controller Manager](https://github.com/k
 
 ## Requirements
 
-- Kubernetes = `1.27.x`
+- Kubernetes = `1.30.x`
 - Kustomize >= `v3.5.3`
 - control plane and worker nodes must be provisioned with cloud-provider `external` on `kubeadm.yaml`
 - `disk.EnableUUID=1` on all nodes.
@@ -15,7 +15,7 @@ This katalog deploys the [vSphere Cloud Controller Manager](https://github.com/k
 
 ## Image repository and tag
 
-- vSphere cloud controller manager image: `gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.27.0`
+- vSphere cloud controller manager image: `gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.30.0`
 
 ## Setting credentials
 

--- a/katalog/vsphere-cm/kustomization.yaml
+++ b/katalog/vsphere-cm/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - vsphere-cloud-controller-manager.yaml
 
 images:
-  - name: gcr.io/cloud-provider-vsphere/cpi/release/manager
-    newName: registry.sighup.io/fury/vsphere/vsphere-cpi-manager
+  - name: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere
+    newName: registry.sighup.io/fury/cloud-pv-vsphere/cloud-provider-vsphere

--- a/katalog/vsphere-cm/vsphere-cloud-controller-manager.yaml
+++ b/katalog/vsphere-cm/vsphere-cloud-controller-manager.yaml
@@ -234,7 +234,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
-          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.29.0
+          image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
           args:
             - --cloud-provider=vsphere
             - --v=2

--- a/katalog/vsphere-csi/MAINTENANCE.md
+++ b/katalog/vsphere-csi/MAINTENANCE.md
@@ -11,5 +11,8 @@ You can use `go-getter` to download the files more easily:
 # install go-getter if you don't have it in your system:
 $ go install github.com/hashicorp/go-getter@latest
 # Get the files. Pay attention to the ?ref= parameter, you should put the right tag there.
-$ go-getter "github.com/kubernetes-sigs/vsphere-csi-driver.git?ref=v3.1.2//manifests//vanilla" /tmp/vanilla
+$ go-getter "github.com/kubernetes-sigs/vsphere-csi-driver.git?ref=v3.3.1//manifests//vanilla" /tmp/vanilla
 ```
+
+## NOTE
+- Since vsphere-csi is now a public project, you must change the currently base images used in the `vanilla` manifests gcr.io/cloud-provider-vsphere/csi` with `registry.k8s.io/csi-vsphere/`  

--- a/katalog/vsphere-csi/README.md
+++ b/katalog/vsphere-csi/README.md
@@ -8,8 +8,8 @@ Follow all the [prerequisites from `vsphere-cm` modules](../vsphere-cm/).
 
 ## Image repository and tag
 
-- `gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2`
-- `gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.2`
+- `gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.1`
+- `gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.1`
 - `k8s.gcr.io/sig-storage/csi-attacher:v4.3.0`
 - `k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.8.0`
 - `k8s.gcr.io/sig-storage/csi-provisioner:v3.5.0`

--- a/katalog/vsphere-csi/README.md
+++ b/katalog/vsphere-csi/README.md
@@ -8,14 +8,14 @@ Follow all the [prerequisites from `vsphere-cm` modules](../vsphere-cm/).
 
 ## Image repository and tag
 
-- `gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.1`
-- `gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.1`
-- `k8s.gcr.io/sig-storage/csi-attacher:v4.3.0`
-- `k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.8.0`
-- `k8s.gcr.io/sig-storage/csi-provisioner:v3.5.0`
-- `k8s.gcr.io/sig-storage/csi-resizer:v1.8.0`
-- `k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.2`
-- `k8s.gcr.io/sig-storage/livenessprobe:v2.10.0`
+- `registry.sighup.io/fury/csi-vsphere/driver:v3.3.1`
+- `registry.sighup.io/fury/csi-vsphere/syncer:v3.3.1`
+- `registry.sighup.io/fury/sig-storage/csi-attacher:v4.5.1`
+- `registry.sighup.io/fury/sig-storage/csi-node-driver-registrar:v2.10.0`
+- `registry.sighup.io/fury/sig-storage/csi-provisioner:v4.0.1`
+- `registry.sighup.io/fury/sig-storage/csi-resizer:v1.10.1`
+- `registry.sighup.io/fury/sig-storage/csi-snapshotter:v7.0.2`
+- `registry.sighup.io/fury/sig-storage/livenessprobe:v2.12.0`
 
 ## Setting credentials
 

--- a/katalog/vsphere-csi/kustomization.yaml
+++ b/katalog/vsphere-csi/kustomization.yaml
@@ -9,19 +9,19 @@ resources:
   - vsphere-csi-driver.yaml
 
 images:
-  - name: k8s.gcr.io/sig-storage/livenessprobe
+  - name: registry.k8s.io/sig-storage/livenessprobe
     newName: registry.sighup.io/fury/vsphere/livenessprobe
-  - name: k8s.gcr.io/sig-storage/csi-attacher
+  - name: registry.k8s.io/sig-storage/csi-attacher
     newName: registry.sighup.io/fury/vsphere/csi-attacher
-  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+  - name: registry.k8s.io/sig-storage/csi-snapshotter
     newName: registry.sighup.io/fury/vsphere/csi-snapshotter
-  - name: k8s.gcr.io/sig-storage/csi-resizer
+  - name: registry.k8s.io/sig-storage/csi-resizer
     newName: registry.sighup.io/fury/vsphere/csi-resizer
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
+  - name: registry.k8s.io/sig-storage/csi-provisioner
     newName: registry.sighup.io/fury/vsphere/csi-provisioner
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  - name: registry.k8s.io/sig-storage/csi-node-driver-registrar
     newName: registry.sighup.io/fury/vsphere/csi-node-driver-registrar
-  - name: gcr.io/cloud-provider-vsphere/csi/release/driver
-    newName: registry.sighup.io/fury/vsphere/vsphere-csi-driver
-  - name: gcr.io/cloud-provider-vsphere/csi/release/syncer
-    newName: registry.sighup.io/fury/vsphere/vsphere-csi-syncer
+  - name: registry.k8s.io/csi-vsphere/driver
+    newName: registry.sighup.io/fury/csi-vsphere/syncer
+  - name: registry.k8s.io/csi-vsphere/syncer
+    newName: registry.sighup.io/fury/csi-vsphere/syncer

--- a/katalog/vsphere-csi/vsphere-csi-driver.yaml
+++ b/katalog/vsphere-csi/vsphere-csi-driver.yaml
@@ -267,7 +267,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.3.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -329,7 +329,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.1
+          image: registry.k8s.io/csi-vsphere/syncer:v3.3.1
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -464,7 +464,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.1
+          image: registry.k8s.io/csi-vsphere/driver:v3.3.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/katalog/vsphere-csi/vsphere-csi-driver.yaml
+++ b/katalog/vsphere-csi/vsphere-csi-driver.yaml
@@ -230,7 +230,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -248,7 +248,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -267,7 +267,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.2.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -329,7 +329,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.2.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.1
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -368,7 +368,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -390,7 +390,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -441,7 +441,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -464,7 +464,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.2.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION
- Upgraded CSI vsphere images for k8s 1.30
- Removed old image registry from gcr.io to registry.k8s.io

Note: there aren't release plans for 1.31+ vsphere csi